### PR TITLE
Remove runtime dep on gulp-dr-frankenstyle

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "correcting-interval": "^2.0.0",
     "express": "^4.12.3",
     "faker": "^2.1.2",
-    "gulp-dr-frankenstyle": "0.0.5",
     "lodash.compact": "^3.0.0",
     "lodash.flatten": "^3.0.1",
     "lodash.groupby": "^3.0.0",


### PR DESCRIPTION
This removes the duplicate dependency clash from #5. Guessing you only want gulp deps in dev.